### PR TITLE
Fix ExecCredential expiration timestamp

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,8 +46,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	d := time.Until(svid.Expiry) / 2
-	expiry, err := metav1.NewTime(svid.Expiry.Add(d)).MarshalJSON()
+	now := time.Now()
+	expiry, err := metav1.NewTime(credentialExpiration(now, svid.Expiry)).MarshalJSON()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -58,4 +58,8 @@ func main() {
 	fmt.Print("status:\n")
 	fmt.Printf("  expirationTimestamp: %s\n", string(expiry))
 	fmt.Printf("  token: %s\n", svid.Marshal())
+}
+
+func credentialExpiration(now, jwtExpiry time.Time) time.Time {
+	return now.Add(jwtExpiry.Sub(now) / 2)
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCredentialExpirationIsHalfwayToJWTExpiry(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 10, 0, 0, 0, time.UTC)
+	jwtExpiry := now.Add(time.Hour)
+	want := now.Add(30 * time.Minute)
+
+	if got := credentialExpiration(now, jwtExpiry); !got.Equal(want) {
+		t.Fatalf("credentialExpiration() = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #14.

## Summary

Report the ExecCredential expiration halfway between the current time and the
JWT-SVID's real expiry. The previous calculation added half of the remaining
lifetime to the JWT expiry itself, so client-go could cache the credential past
the JWT's `exp` and send one request that received 401 before recovering.

The focused unit test fixes the clock at 10:00 with a JWT expiring at 11:00 and
asserts that the reported credential expiration is 10:30.

## Testing

- `go test ./...`
- `go vet ./...`
