### PR TITLE
release: build on the newest patch of the go.mod line

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,13 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          # Build releases on the newest patch of the go.mod line, so a
+          # released binary does not ship a standard library with known
+          # vulnerabilities. Without check-latest the toolchain resolves to
+          # exactly the go.mod version.
+          go-version-file: go.mod
+          check-latest: true
       - uses: ko-build/setup-ko@v0.6
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## Problem

The released binary ships a Go standard library with known vulnerabilities.
`v0.2.0` carries **stdlib go1.25.0**, and scanners flag several advisories
against it — including **GO-2026-4337** (crypto/tls session resumption) at
**critical**.

## Cause

`release.yaml` uses `actions/setup-go` with **no version input**, so the
toolchain resolves to exactly the `go 1.25.0` in `go.mod`:

```yaml
- name: Set up Go
  uses: actions/setup-go@v5        # no go-version / go-version-file
```

`test.yaml` already passes `go-version-file: 'go.mod'` in both jobs —
`release.yaml` is the only workflow that does not, which reads like an
oversight rather than a deliberate choice.

## Fix

Add `go-version-file` plus `check-latest: true`, so releases build on the
**newest patch of the same line**. No change to the language version in
`go.mod` is needed.

## Measurements

Built `cmd@v0.2.0` under different toolchains and scanned each with grype:

| toolchain | findings | critical |
|---|---|---|
| **go1.25.0** (what v0.2.0 shipped) | 34 | **1** |
| **go1.25.7** | 22 | **0** |
| go1.26.5 (current stable) | 8 | 0 |

Staying on the 1.25 line is enough to clear the critical, so this is the
smallest change that fixes it. Reproduced the current release exactly with
`GOTOOLCHAIN=go1.25.0` before and after, so the difference is the toolchain
and nothing else.

## Why it matters downstream

This binary is consumed as a container base layer — copied into other images
with `COPY --from=ghcr.io/spiffe/k8s-spiffe-workload-jwt-exec-auth:0.2.0`.
The finding then surfaces in image scans of everything that includes it, and
**a consumer cannot fix it**: `v0.2.0` is the latest release, `latest` is the
same digest, and `main` is zero commits ahead, so there is no newer tag to
move to.

A re-release built on a patched toolchain would clear it for every consumer at
once.

Happy to adjust the approach — `go-version: stable` would also work if you
would rather releases always track current stable.
