### PR TITLE
Add optional RFC 8693 token exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 A Kubernetes exec auth plugin that gets a SPIFFE JWT-SVID for authentication,
 either from the SPIFFE Workload API (default) or by minting one from the SPIRE
-Server admin API.
+Server admin API. It can optionally exchange that JWT-SVID for a token issued by
+a token exchange before presenting it.
 
 ## Building
 
@@ -22,17 +23,19 @@ kubeconfig `exec` block:
 | --- | --- | --- |
 | `SPIFFE_JWT_SOURCE` | `workload-api` | Where the JWT-SVID comes from: `workload-api` or `server-admin-api`. See below. |
 | `SPIFFE_ENDPOINT_SOCKET` | `unix:///tmp/spire-agent/public/api.sock` | Address of the SPIFFE Workload API socket. `workload-api` source only. |
-| `SPIFFE_JWT_AUDIENCE` | `k8s` | Audience requested for the JWT-SVID. Must match an entry in the API server's `AuthenticationConfiguration`. |
+| `SPIFFE_JWT_AUDIENCE` | `k8s` | Audience requested for the JWT-SVID. Must match an entry in the API server's `AuthenticationConfiguration`, unless an exchange requires otherwise. |
 | `SPIFFE_JWT_HINT` | *(unset)* | Selects which JWT-SVID to use by hint, when the Workload API returns more than one. `workload-api` source only. See below. |
 | `EXEC_CREDENTIAL_VERSION` | `v1` | The `client.authentication.k8s.io` version emitted. Use `v1beta1` for older clients. Must match the `apiVersion` in the `exec` block. |
 | `SPIRE_SERVER_SOCKET` | `unix:///tmp/spire-server/private/api.sock` | Address of the SPIRE Server admin API socket. `server-admin-api` source only. |
 | `SPIFFE_ID` | *(unset)* | The SPIFFE ID to mint a JWT-SVID for. Required for the `server-admin-api` source. |
+| `SPIFFE_JWT_EXCHANGE_ENDPOINT` | *(unset)* | RFC 8693 token exchange endpoint, `https://` only. See below. |
+| `SPIFFE_JWT_EXCHANGE_AUDIENCE` | *(unset)* | RFC 8693 `audience` for the issued token, sent only when set. See below. |
 
 There is also one flag, passed via `args:` rather than `env:`:
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `-timeout` | `0` | Max time to wait for the JWT-SVID, e.g. `-timeout=5s`. `0` waits forever. |
+| `-timeout` | `0` | Max time to wait for the credential, including any token exchange, e.g. `-timeout=5s`. `0` waits forever. |
 
 ### Choosing a JWT source with `SPIFFE_JWT_SOURCE`
 
@@ -61,6 +64,45 @@ Set `SPIFFE_JWT_HINT` to pin a specific one:
 
 Matching is exact — no case folding or whitespace trimming. SPIRE keeps only the first SVID for each
 non-empty hint, so hints are effectively unique.
+
+### Exchanging the JWT-SVID with `SPIFFE_JWT_EXCHANGE_ENDPOINT`
+
+Some clusters trust a token exchange as their issuer instead of trusting SPIRE directly, and a
+JWT-SVID is not a credential those clusters accept. Set `SPIFFE_JWT_EXCHANGE_ENDPOINT` and the
+plugin trades the JWT-SVID for a token from that exchange, using the
+[RFC 8693](https://www.rfc-editor.org/rfc/rfc8693) token-exchange grant, then presents that
+instead:
+
+```
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+subject_token=<the JWT-SVID>
+subject_token_type=urn:ietf:params:oauth:token-type:jwt
+```
+
+This works with either `SPIFFE_JWT_SOURCE`.
+
+There are two audiences, and which one you need depends on the exchange. `SPIFFE_JWT_AUDIENCE` is
+the audience SPIRE puts in the JWT-SVID. `SPIFFE_JWT_EXCHANGE_AUDIENCE` is the `audience` parameter
+sent to the exchange, and is only sent if you set it. Google Cloud's STS requires that parameter.
+Other exchanges take the audience from the subject token and reject a request that sends one.
+Either way, the token you end up with has to carry the audience in the cluster's
+`AuthenticationConfiguration`.
+
+If the exchange fails, the plugin exits non-zero and prints the exchange's own `error` and
+`error_description`. It does not fall back to the unexchanged JWT-SVID.
+
+- **The endpoint sees a live JWT-SVID** on every refresh, and it comes from a kubeconfig, which
+  people copy and share. Treat it as trusted. It has to be `https://`, and redirects are refused —
+  following one would send the JWT-SVID to a host that was never checked. For a private CA, add
+  that CA to the system trust store.
+- **`expires_in` is required**, even though RFC 8693 only recommends it. Without it there is no
+  expiry to report, and client-go caches the credential for the life of the process and only
+  refreshes it after a 401.
+- **`-timeout` covers the exchange**, not just the fetch. Set it — the default waits forever, and
+  this is a call to a remote host.
+- **No client authentication is sent.** RFC 8693 leaves that to the exchange, and the JWT-SVID is
+  itself the credential. If an exchange wants a client secret or client certificate on top of the
+  subject token, this plugin cannot talk to it.
 
 ## Usage
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"math"
+	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,6 +39,13 @@ const (
 	sourceServerAdminAPI = "server-admin-api"
 )
 
+// RFC 8693 (https://www.rfc-editor.org/rfc/rfc8693) token exchange constants.
+const (
+	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+	// A JWT-SVID is always a JWT, whichever source produced it.
+	tokenTypeJWT = "urn:ietf:params:oauth:token-type:jwt"
+)
+
 func main() {
 	// client-go inherits this process's stderr and reports only "failed with exit
 	// code N", so anything logged here is the operator's entire diagnostic. Drop
@@ -41,7 +54,7 @@ func main() {
 	log.SetPrefix("k8s-spiffe-workload-jwt-exec-auth: ")
 
 	timeout := flag.Duration("timeout", 0,
-		"max time to wait for the JWT-SVID (e.g. 5s). 0 = wait forever")
+		"max time to wait for the credential, including any token exchange (e.g. 5s). 0 = wait forever")
 	flag.Parse()
 
 	audience, ok := os.LookupEnv("SPIFFE_JWT_AUDIENCE")
@@ -57,6 +70,14 @@ func main() {
 	source, ok := os.LookupEnv("SPIFFE_JWT_SOURCE")
 	if !ok {
 		source = sourceWorkloadAPI
+	}
+
+	// Validated before the JWT-SVID is fetched, so a typo fails immediately.
+	exchangeEndpoint := os.Getenv("SPIFFE_JWT_EXCHANGE_ENDPOINT")
+	if exchangeEndpoint != "" {
+		if err := validateExchangeEndpoint(exchangeEndpoint); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	ctx := context.Background()
@@ -102,6 +123,14 @@ func main() {
 	}
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if exchangeEndpoint != "" {
+		exchangeAudience := os.Getenv("SPIFFE_JWT_EXCHANGE_AUDIENCE")
+		token, expiry, err = exchangeToken(ctx, exchangeEndpoint, token, exchangeAudience)
+		if err != nil {
+			log.Fatalf("token exchange failed: %v", err)
+		}
 	}
 
 	now := time.Now()
@@ -201,4 +230,121 @@ func mintFromServerAdminAPI(ctx context.Context, target, spiffeID, audience stri
 		return "", time.Time{}, errors.New("no JWT-SVID in mint response")
 	}
 	return resp.Svid.Token, time.Unix(resp.Svid.ExpiresAt, 0), nil
+}
+
+// validateExchangeEndpoint rejects an endpoint this plugin should not send a
+// JWT-SVID to. TLS is not configurable: the credential leaves the machine here.
+func validateExchangeEndpoint(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid SPIFFE_JWT_EXCHANGE_ENDPOINT %q: %w", raw, err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("SPIFFE_JWT_EXCHANGE_ENDPOINT %q must be an https:// URL", raw)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("SPIFFE_JWT_EXCHANGE_ENDPOINT %q has no host", raw)
+	}
+	return nil
+}
+
+// exchangeResponse is the part of the RFC 8693 section 2.2.1 response used here.
+type exchangeResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in"`
+}
+
+// exchangeError is the RFC 6749 section 5.2 error response RFC 8693 defers to.
+type exchangeError struct {
+	Error       string `json:"error"`
+	Description string `json:"error_description"`
+}
+
+// exchangeToken trades subjectToken for one the exchange at endpoint issues,
+// using the RFC 8693 grant. audience is sent only when set: RFC 8693 makes it
+// optional, and exchanges split on whether they require it or derive it from the
+// subject token and reject a request carrying it.
+func exchangeToken(ctx context.Context, endpoint, subjectToken, audience string) (string, time.Time, error) {
+	form := url.Values{
+		"grant_type":         {grantTypeTokenExchange},
+		"subject_token":      {subjectToken},
+		"subject_token_type": {tokenTypeJWT},
+	}
+	if audience != "" {
+		form.Set("audience", audience)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// Redirects are refused: validateExchangeEndpoint checks only the first hop,
+	// and net/http replays a POST body on a 307 or 308 without requiring the target
+	// to still be https. A token endpoint has no reason to redirect.
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			return fmt.Errorf("the exchange redirected to %q; a token endpoint must not redirect", req.URL.Redacted())
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Bounds memory, not time; -timeout bounds how long the endpoint may take.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("reading the exchange response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var e exchangeError
+		if json.Unmarshal(body, &e) != nil || e.Error == "" {
+			return "", time.Time{}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, quoteForTerminal(string(body)))
+		}
+		if e.Description == "" {
+			return "", time.Time{}, fmt.Errorf("%s (HTTP %d)", quoteForTerminal(e.Error), resp.StatusCode)
+		}
+		return "", time.Time{}, fmt.Errorf("%s: %s (HTTP %d)", quoteForTerminal(e.Error), quoteForTerminal(e.Description), resp.StatusCode)
+	}
+
+	var parsed exchangeResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		// A 200 body that fails to decode still holds the access token, so print it
+		// only when it is not JSON at all and so cannot have come from the exchange.
+		if !json.Valid(body) {
+			return "", time.Time{}, fmt.Errorf("parsing the exchange response: %w: %s", err, quoteForTerminal(string(body)))
+		}
+		return "", time.Time{}, fmt.Errorf("parsing the exchange response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return "", time.Time{}, errors.New("the exchange response has no access_token")
+	}
+	// A newline here would corrupt the ExecCredential written to stdout, which is
+	// assembled by hand. RFC 6749 appendix A.12 limits an access token to %x20-7E,
+	// so a conforming token always passes this check.
+	if strings.ContainsFunc(parsed.AccessToken, func(r rune) bool { return r < 0x20 || r > 0x7e }) {
+		return "", time.Time{}, errors.New("the exchange returned an access_token with characters outside printable ASCII")
+	}
+	// expires_in is only RECOMMENDED by RFC 8693, but without it there is no expiry
+	// to report. The upper bound keeps the multiplication below from overflowing.
+	if parsed.ExpiresIn <= 0 || parsed.ExpiresIn > math.MaxInt32 {
+		return "", time.Time{}, fmt.Errorf("the exchange response has no usable expires_in (got %d), which is required to report a credential expiry", parsed.ExpiresIn)
+	}
+
+	return parsed.AccessToken, time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second), nil
+}
+
+// quoteForTerminal makes exchange-supplied bytes safe and short for stderr.
+func quoteForTerminal(s string) string {
+	const max = 256
+	s = strings.TrimSpace(s)
+	if len(s) > max {
+		s = s[:max] + "..."
+	}
+	return strconv.Quote(s)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -144,7 +144,7 @@ func main() {
 	fmt.Print(" interactive: false\n")
 	fmt.Print("status:\n")
 	fmt.Printf("  expirationTimestamp: %s\n", string(expiration))
-	fmt.Printf("  token: %s\n", token)
+	fmt.Printf("  token: %q\n", token)
 }
 
 func credentialExpiration(now, jwtExpiry time.Time) time.Time {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -123,5 +130,326 @@ func TestSelectSVIDByHint(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateExchangeEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		// wantErrs lists substrings the error must contain. Empty means expect success.
+		wantErrs []string
+	}{
+		{
+			name:     "https endpoint",
+			endpoint: "https://exchange.example.org/token",
+		},
+		{
+			name:     "http is rejected",
+			endpoint: "http://exchange.example.org/token",
+			wantErrs: []string{"must be an https:// URL"},
+		},
+		{
+			name:     "no scheme is rejected",
+			endpoint: "exchange.example.org/token",
+			wantErrs: []string{"must be an https:// URL"},
+		},
+		{
+			name:     "no host is rejected",
+			endpoint: "https:///token",
+			wantErrs: []string{"has no host"},
+		},
+		{
+			name:     "unparseable url is rejected",
+			endpoint: "https://exchange.example.org/token\x7f",
+			wantErrs: []string{"invalid SPIFFE_JWT_EXCHANGE_ENDPOINT"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExchangeEndpoint(tt.endpoint)
+
+			if len(tt.wantErrs) == 0 {
+				if err != nil {
+					t.Fatalf("validateExchangeEndpoint(%q) returned unexpected error: %v", tt.endpoint, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateExchangeEndpoint(%q) = nil, want an error", tt.endpoint)
+			}
+			for _, want := range tt.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("validateExchangeEndpoint(%q) error = %q, want it to contain %q", tt.endpoint, err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestExchangeTokenRequest pins the RFC 8693 wire format against renames, and
+// that audience is sent only when asked for — an exchange that derives it from
+// the subject token rejects a request that carries one.
+func TestExchangeTokenRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		audience string
+		// expiresIn differs per case so the expiry cannot come from a constant.
+		expiresIn int64
+		// wantAudience is the value the exchange must receive. Empty means the
+		// parameter must be absent, not present and empty.
+		wantAudience []string
+	}{
+		{
+			name:      "no audience requested",
+			expiresIn: 600,
+		},
+		{
+			expiresIn:    1800,
+			name:         "audience requested",
+			audience:     "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/v",
+			wantAudience: []string{"//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/v"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseForm(); err != nil {
+					t.Errorf("ParseForm() returned unexpected error: %v", err)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+					t.Errorf("Content-Type = %q, want %q", got, "application/x-www-form-urlencoded")
+				}
+				if want := "urn:ietf:params:oauth:grant-type:token-exchange"; r.PostForm.Get("grant_type") != want {
+					t.Errorf("grant_type = %q, want %q", r.PostForm.Get("grant_type"), want)
+				}
+				if got := r.PostForm.Get("subject_token"); got != "subject-jwt" {
+					t.Errorf("subject_token = %q, want %q", got, "subject-jwt")
+				}
+				if want := "urn:ietf:params:oauth:token-type:jwt"; r.PostForm.Get("subject_token_type") != want {
+					t.Errorf("subject_token_type = %q, want %q", r.PostForm.Get("subject_token_type"), want)
+				}
+				if got := r.PostForm["audience"]; !slices.Equal(got, tt.wantAudience) {
+					t.Errorf("audience = %q, want %q", got, tt.wantAudience)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				body := fmt.Sprintf(`{"access_token":"exchanged","issued_token_type":"urn:ietf:params:oauth:token-type:jwt","token_type":"Bearer","expires_in":%d}`, tt.expiresIn)
+				if _, err := w.Write([]byte(body)); err != nil {
+					t.Errorf("Write() returned unexpected error: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			before := time.Now()
+			token, expiry, err := exchangeToken(context.Background(), server.URL, "subject-jwt", tt.audience)
+			if err != nil {
+				t.Fatalf("exchangeToken() returned unexpected error: %v", err)
+			}
+
+			if token != "exchanged" {
+				t.Errorf("exchangeToken() token = %q, want %q", token, "exchanged")
+			}
+			if want := before.Add(time.Duration(tt.expiresIn) * time.Second); expiry.Before(want) || expiry.After(want.Add(time.Minute)) {
+				t.Errorf("exchangeToken() expiry = %s, want about %s", expiry, want)
+			}
+		})
+	}
+}
+
+// TestExchangeTokenRefusesRedirect covers what validateExchangeEndpoint cannot:
+// net/http replays a POST body on a 307, which could reach a plaintext host.
+func TestExchangeTokenRefusesRedirect(t *testing.T) {
+	var redirected atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirected.Store(true)
+	}))
+	defer target.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	token, _, err := exchangeToken(context.Background(), server.URL, "subject-jwt", "")
+	if err == nil {
+		t.Fatalf("exchangeToken() = %q, want an error", token)
+	}
+	if !strings.Contains(err.Error(), "must not redirect") {
+		t.Errorf("exchangeToken() error = %q, want it to name the redirect", err)
+	}
+	if redirected.Load() {
+		t.Error("exchangeToken() followed the redirect, sending the subject token to the target")
+	}
+}
+
+func TestExchangeTokenErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		// wantErrs lists substrings the error must contain.
+		wantErrs []string
+	}{
+		{
+			name:     "rfc 6749 error with a description",
+			status:   http.StatusBadRequest,
+			body:     `{"error":"invalid_grant","error_description":"subject token is expired"}`,
+			wantErrs: []string{`"invalid_grant": "subject token is expired" (HTTP 400)`},
+		},
+		{
+			name:     "rfc 6749 error without a description",
+			status:   http.StatusForbidden,
+			body:     `{"error":"unauthorized_client"}`,
+			wantErrs: []string{`"unauthorized_client" (HTTP 403)`},
+		},
+		{
+			name:     "non-json error body is reported with its status, trimmed",
+			status:   http.StatusBadGateway,
+			body:     "  upstream unavailable\n",
+			wantErrs: []string{`HTTP 502: "upstream unavailable"`},
+		},
+		{
+			name:     "unparseable success body keeps the evidence",
+			status:   http.StatusOK,
+			body:     "<html>captive portal</html>",
+			wantErrs: []string{"parsing the exchange response", "captive portal"},
+		},
+		{
+			name:     "success without an access token",
+			status:   http.StatusOK,
+			body:     `{"expires_in":600}`,
+			wantErrs: []string{"no access_token"},
+		},
+		{
+			// DEL, the upper end of the range: printable ASCII stops at 0x7e.
+			name:     "access token with a DEL character",
+			status:   http.StatusOK,
+			body:     "{\"access_token\":\"tok\\u007f\",\"expires_in\":600}",
+			wantErrs: []string{"outside printable ASCII"},
+		},
+		{
+			name:     "access token with a control character",
+			status:   http.StatusOK,
+			body:     "{\"access_token\":\"line\\nbreak\",\"expires_in\":600}",
+			wantErrs: []string{"outside printable ASCII"},
+		},
+		{
+			name:     "success without expires_in",
+			status:   http.StatusOK,
+			body:     `{"access_token":"exchanged","token_type":"Bearer"}`,
+			wantErrs: []string{"no usable expires_in"},
+		},
+		{
+			name:     "negative expires_in",
+			status:   http.StatusOK,
+			body:     `{"access_token":"exchanged","expires_in":-1}`,
+			wantErrs: []string{"no usable expires_in"},
+		},
+		{
+			// math.MaxInt32 + 1, so time.Duration(n) * time.Second cannot overflow.
+			name:     "expires_in above the overflow guard",
+			status:   http.StatusOK,
+			body:     `{"access_token":"exchanged","expires_in":2147483648}`,
+			wantErrs: []string{"no usable expires_in"},
+		},
+		{
+			// One byte over the limit, so this pins where quoteForTerminal cuts.
+			name:     "an oversized error body is truncated at 256 bytes",
+			status:   http.StatusBadGateway,
+			body:     strings.Repeat("a", 257),
+			wantErrs: []string{`HTTP 502: "` + strings.Repeat("a", 256) + `..."`},
+		},
+		{
+			// JSON but not the RFC 6749 shape: without the e.Error guard, an empty code.
+			name:     "json error body without an error member keeps the body",
+			status:   http.StatusBadGateway,
+			body:     `{"message":"upstream unavailable"}`,
+			wantErrs: []string{`HTTP 502: "{\"message\":\"upstream unavailable\"}"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				if _, err := w.Write([]byte(tt.body)); err != nil {
+					t.Errorf("Write() returned unexpected error: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			token, _, err := exchangeToken(context.Background(), server.URL, "subject-jwt", "")
+
+			if err == nil {
+				t.Fatalf("exchangeToken() = %q, want an error", token)
+			}
+			if token != "" {
+				t.Errorf("exchangeToken() returned token %q alongside an error, want no token", token)
+			}
+			for _, want := range tt.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("exchangeToken() error = %q, want it to contain %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestExchangeTokenDoesNotEchoTokenBearingBody covers the one response that must
+// not reach stderr: a 200 whose expires_in is a JSON string aborts the decode
+// with the issued token still in the body, and client-go inherits our stderr.
+func TestExchangeTokenDoesNotEchoTokenBearingBody(t *testing.T) {
+	const issued = "the-issued-token"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{"access_token":"` + issued + `","token_type":"Bearer","expires_in":"600"}`)); err != nil {
+			t.Errorf("Write() returned unexpected error: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	_, _, err := exchangeToken(context.Background(), server.URL, "subject-jwt", "")
+	if err == nil {
+		t.Fatal("exchangeToken() = nil error, want a decode error")
+	}
+	if strings.Contains(err.Error(), issued) {
+		t.Errorf("exchangeToken() error = %q, want it not to contain the issued token", err)
+	}
+	// The operator still needs to know which member did not decode.
+	if !strings.Contains(err.Error(), "expires_in") {
+		t.Errorf("exchangeToken() error = %q, want it to name the member that failed", err)
+	}
+}
+
+// TestExchangeTokenHonoursContext covers -timeout reaching the exchange.
+func TestExchangeTokenHonoursContext(t *testing.T) {
+	// The handler blocks until the test releases it, not until the request context
+	// is done: cancelling the client side does not reliably unblock the server
+	// side, and Server.Close waits for handlers. Released before the close.
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	errs := make(chan error, 1)
+	go func() {
+		_, _, err := exchangeToken(ctx, server.URL, "subject-jwt", "")
+		errs <- err
+	}()
+
+	select {
+	case err := <-errs:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("exchangeToken() error = %v, want %v", err, context.DeadlineExceeded)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("exchangeToken() did not return once the context deadline passed")
 	}
 }


### PR DESCRIPTION

## Add optional RFC 8693 token exchange

Some clusters trust a token exchange as their issuer instead of trusting SPIRE directly. A
JWT-SVID is not a credential those clusters accept, so today this plugin cannot be used with them
at all.

Set `SPIFFE_JWT_EXCHANGE_ENDPOINT` and the plugin trades the JWT-SVID for a token from that
exchange, using the [RFC 8693](https://www.rfc-editor.org/rfc/rfc8693) token-exchange grant, then
presents that instead:

```
grant_type=urn:ietf:params:oauth:grant-type:token-exchange
subject_token=<the JWT-SVID>
subject_token_type=urn:ietf:params:oauth:token-type:jwt
audience=<SPIFFE_JWT_EXCHANGE_AUDIENCE, only sent if you set it>
```

**If you don't set the endpoint, nothing changes.** The plugin behaves exactly as it does today.

This is not a third `SPIFFE_JWT_SOURCE`. The exchange takes a JWT-SVID and returns a different
token, so it is a step after the fetch and works with either source.

If the exchange fails, the plugin exits non-zero and prints the exchange's own `error` and
`error_description`. It does not fall back to the unexchanged JWT-SVID.

## Design notes

**The endpoint must be `https://`, and redirects are refused.** This is the first time the plugin
sends a credential off the machine. Checking the URL is not enough on its own: Go replays a POST
body on a 307 or 308, and does not require the new target to still be https, so an endpoint that
passed the check could hand the live JWT-SVID to a plaintext host. A token endpoint has no reason
to redirect. For a private CA, add the CA to the system trust store.

**There are two audiences, because exchanges disagree about them.** `SPIFFE_JWT_AUDIENCE` is the
audience SPIRE puts in the JWT-SVID. `SPIFFE_JWT_EXCHANGE_AUDIENCE` is the `audience` parameter
sent to the exchange. Google Cloud's STS requires that parameter — its own RFC 8693 client in
`golang.org/x/oauth2/google/externalaccount` will not build a request without one. Other exchanges
take the audience from the subject token and reject a request that sends one. Hardcoding it either
way would rule out real implementations, so it is sent only when set.

## Testing

Unit tests use an `httptest` server and cover the request parameters, both RFC 6749 error
renderings, malformed and oversized responses, refusing to follow a redirect, and `-timeout`
reaching the exchange.

I also ran the built plugin end to end against a real SPIRE server and agent and a conforming
RFC 8693 exchange. With the endpoint unset it emits the JWT-SVID as before. With it set, the
ExecCredential carries a token issued by the exchange, with the subject and audience preserved.

## Left out

`resource`, `scope`, `requested_token_type` and `actor_token`, until someone needs them. An exchange
that wants a client secret or client certificate on top of the subject token is not supported.

Closes #25 